### PR TITLE
Skip sanitize when only one bracket is present

### DIFF
--- a/html_terminator.gemspec
+++ b/html_terminator.gemspec
@@ -21,5 +21,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
 
-  spec.add_runtime_dependency "sanitize"
+  spec.add_runtime_dependency "sanitize", "~> 4.0"
 end

--- a/lib/html_terminator.rb
+++ b/lib/html_terminator.rb
@@ -7,8 +7,14 @@ module HtmlTerminator
   }
 
   def self.sanitize(val)
-    if val and val.is_a?(String)
-      Sanitize.clean(val, SANITIZE_OPTIONS).strip
+    if val && val.is_a?(String)
+      # Temporary fix: skip sanitization if only one bracket.
+      # Allows answers like "1 < 2"
+      if val.count("<") + val.count(">") == 1
+        val
+      else
+        Sanitize.clean(val, SANITIZE_OPTIONS).strip.gsub(/&amp;/, "&")
+      end
     else
       val
     end

--- a/lib/html_terminator.rb
+++ b/lib/html_terminator.rb
@@ -8,7 +8,7 @@ module HtmlTerminator
 
   def self.sanitize(val)
     if val.is_a?(String) && !skip_sanitize?(val)
-      Sanitize.clean(val, SANITIZE_OPTIONS).strip.gsub(/&amp;/, "&")
+      Sanitize.fragment(val, SANITIZE_OPTIONS).strip.gsub(/&amp;/, "&")
     else
       val
     end

--- a/lib/html_terminator.rb
+++ b/lib/html_terminator.rb
@@ -7,17 +7,17 @@ module HtmlTerminator
   }
 
   def self.sanitize(val)
-    if val && val.is_a?(String)
-      # Temporary fix: skip sanitization if only one bracket.
-      # Allows answers like "1 < 2"
-      if val.count("<") + val.count(">") == 1
-        val
-      else
-        Sanitize.clean(val, SANITIZE_OPTIONS).strip.gsub(/&amp;/, "&")
-      end
+    if val.is_a?(String) && !skip_sanitize?(val)
+      Sanitize.clean(val, SANITIZE_OPTIONS).strip.gsub(/&amp;/, "&")
     else
       val
     end
+  end
+
+  # Don't sanitize if only one bracket is present.
+  # Without this, "1 < 2" gets incorrectly sanitized as "1".
+  def self.skip_sanitize?(val)
+    val.count("<") + val.count(">") == 1
   end
 
   module ClassMethods
@@ -51,9 +51,9 @@ module HtmlTerminator
 
           # sanitize reads
           self.html_terminator_fields.each do |attr|
-            define_method "#{attr}" do |*args|
+            define_method(attr) do |*rargs|
               # sanitize it
-              HtmlTerminator.sanitize super(*args)
+              HtmlTerminator.sanitize super(*rargs)
             end
           end
         end

--- a/spec/html_terminator_spec.rb
+++ b/spec/html_terminator_spec.rb
@@ -31,6 +31,13 @@ describe HtmlTerminator do
     @user.first_name.should == "2 > 1"
   end
 
+  it "handles ampersands" do
+    @user = OnlyFirstName.new
+
+    @user.first_name = "Mr. & Mrs. Smith"
+    @user.first_name.should == "Mr. & Mrs. Smith"
+  end
+
   it "sanitizes all except what is specified" do
     @user = ExceptFirstName.new
 

--- a/spec/html_terminator_spec.rb
+++ b/spec/html_terminator_spec.rb
@@ -14,6 +14,23 @@ describe HtmlTerminator do
     @user.age.should == 3
   end
 
+  it "doesn't escape ampersands" do
+    @user = OnlyFirstName.new
+
+    @user.first_name = "A & B & C"
+    @user.first_name.should == "A & B & C"
+  end
+
+  it "skips sanitize when only one bracket" do
+    @user = OnlyFirstName.new
+
+    @user.first_name = "1 < 2"
+    @user.first_name.should == "1 < 2"
+
+    @user.first_name = "2 > 1"
+    @user.first_name.should == "2 > 1"
+  end
+
   it "sanitizes all except what is specified" do
     @user = ExceptFirstName.new
 


### PR DESCRIPTION
The `skip_one_bracket_sanitize` branch was intended to be temporary, but we've been using it in production since 2013. By merging it into `master`, this PR codifies it as default behavior. We may as well do this because it appears to be a good change, and we're only fooling ourselves if we mark it as "temporary" while using it in production for years.
