### PR TITLE
Escape text that isn't stripped out

### DIFF
--- a/lib/html_terminator.rb
+++ b/lib/html_terminator.rb
@@ -1,14 +1,23 @@
 require "html_terminator/version"
 require "html_terminator/extract_options"
 require "sanitize"
+require "cgi"
 
 module HtmlTerminator
+  ESCAPE_TEXT = lambda do |env|
+    node = env[:node]
+    return unless node.text?
+    node.content = CGI.escape_html node.content
+  end
+
   SANITIZE_OPTIONS = {
-    :elements => []
+    :elements => [],
+    :transformers => [ESCAPE_TEXT]
   }
 
   def self.sanitize(val, config = {})
     if val.is_a?(String)
+      config = SANITIZE_OPTIONS.clone.merge(config)
       # Sanitize produces escaped content.
       # Unescape it to get the raw html
       CGI.unescapeHTML(Sanitize.fragment(val, config).strip).html_safe
@@ -38,7 +47,6 @@ module HtmlTerminator
         end
 
         options = args.extract_options!
-        options = SANITIZE_OPTIONS.clone.merge(options)
 
         valid_fields = self.fields & args
 

--- a/spec/html_terminator_spec.rb
+++ b/spec/html_terminator_spec.rb
@@ -14,28 +14,28 @@ describe HtmlTerminator do
     expect(user.age).to eql(3)
   end
 
-  it "doesn't escape ampersands" do
+  it "escapes ampersands" do
     user = OnlyFirstName.new
 
     user.first_name = "A & B & C"
-    expect(user.first_name).to eql("A & B & C")
+    expect(user.first_name).to eql("A &amp; B &amp; C")
   end
 
-  it "skips sanitize when only one bracket" do
+  it "escapes (but doesn't remove when only one bracket" do
     user = OnlyFirstName.new
 
     user.first_name = "1 < 2"
-    expect(user.first_name).to eql("1 < 2")
+    expect(user.first_name).to eql("1 &lt; 2")
 
     user.first_name = "2 > 1"
-    expect(user.first_name).to eql("2 > 1")
+    expect(user.first_name).to eql("2 &gt; 1")
   end
 
-  it "handles ampersands" do
+  it "escapes ampersands" do
     user = OnlyFirstName.new
 
     user.first_name = "Mr. & Mrs. Smith"
-    expect(user.first_name).to eql("Mr. & Mrs. Smith")
+    expect(user.first_name).to eql("Mr. &amp; Mrs. Smith")
   end
 
   it "doesn't blow up if value is not a string" do
@@ -59,6 +59,11 @@ describe HtmlTerminator do
     it "marks the output as html_safe" do
       val = HtmlTerminator.sanitize "<flexbox></flexbox><hr><br><img>"
       expect(val.html_safe?).to eql(true)
+    end
+
+    it "escapes what isn't stripped out" do
+      val = HtmlTerminator.sanitize '<br>"><br><i>ital</i><b>"><b>', :elements => %w(i)
+      expect(val).to eql("&quot;&gt; <i>ital</i>&quot;&gt;")
     end
   end
 


### PR DESCRIPTION
This is necessary because the resulting strings are marked as html_safe.
Without this, they are not actually html_safe. Attackers can cause the page to include invalid HTML.
