### PR TITLE
Do not mark string as html_safe

### DIFF
--- a/lib/html_terminator.rb
+++ b/lib/html_terminator.rb
@@ -11,7 +11,7 @@ module HtmlTerminator
     if val.is_a?(String)
       # Sanitize produces escaped content.
       # Unescape it to get the raw html
-      CGI.unescapeHTML(Sanitize.fragment(val, config).strip).html_safe
+      CGI.unescapeHTML(Sanitize.fragment(val, config).strip)
     else
       val
     end

--- a/spec/html_terminator_spec.rb
+++ b/spec/html_terminator_spec.rb
@@ -56,9 +56,14 @@ describe HtmlTerminator do
       expect(val).to eql("")
     end
 
-    it "marks the output as html_safe" do
+    it "does not mark the output as html_safe" do
       val = HtmlTerminator.sanitize "<flexbox></flexbox><hr><br><img>"
-      expect(val.html_safe?).to eql(true)
+      expect(val.html_safe?).to eql(false)
+    end
+
+    it "does not escape output that isn't stripped" do
+      val = HtmlTerminator.sanitize "<div>I said, \"Hello, John O'hare.\"</div>"
+      expect(val).to eql("I said, \"Hello, John O'hare.\"")
     end
   end
 


### PR DESCRIPTION
The resulting string is not fully html_safe because it does not escape
the text that isn't stripped.
Prior to this commit, this gem was not fully compatible with
Ruby on Rails form helpers, such as `form.text_field`.

This reverts the following commits:
- 13150be340261495279708980df022f8d08d1f45
- 6234ff3d7e83aa50426e492d996d0dc49596f4ae

This is an alternative to https://github.com/polleverywhere/html_terminator/pull/3
