### PR TITLE
Bump sanitize 5.2.1 -> 6.0.0

### DIFF
--- a/html_terminator.gemspec
+++ b/html_terminator.gemspec
@@ -21,5 +21,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 2.2.0"
   spec.add_development_dependency "rake"
 
-  spec.add_runtime_dependency "sanitize", "~> 5.2.1"
+  spec.add_runtime_dependency "sanitize", "~> 6.0.0"
 end


### PR DESCRIPTION
Bump sanitize gem due to security issue in nokogiri.