### PR TITLE
Ignore connection errors

### DIFF
--- a/lib/html_terminator.rb
+++ b/lib/html_terminator.rb
@@ -58,6 +58,8 @@ module HtmlTerminator
           end
         end
       end
+    rescue ActiveRecord::ConnectionNotEstablished
+      # Treat as if the table doesn't exist
     end
   end
 


### PR DESCRIPTION
If we can't actually connect to the database, we'll assume we don't need
to terminate HTML.

We ran into issues related to this when moving to ruby 2.7 on rails 6.1.
